### PR TITLE
Add support for move operation

### DIFF
--- a/src/jsonpatch2pymongo/main.py
+++ b/src/jsonpatch2pymongo/main.py
@@ -19,7 +19,7 @@ def to_dot(path: str) -> str:
 
 
 def jsonpatch2pymongo(patch_list: list) -> dict:
-    update = {"$set": {}, "$unset": {}, "$push": {}}
+    update = {"$set": {}, "$unset": {}, "$push": {}, "$rename": {}}
     for p in patch_list:
         op, path, value = p["op"], p["path"], p.get("value", None)
         dot_path = to_dot(path)
@@ -69,6 +69,15 @@ def jsonpatch2pymongo(patch_list: list) -> dict:
             update["$unset"][dot_path] = 1
         elif op == "replace":
             update["$set"][dot_path] = value
+        elif op == "move":
+            dot_path = to_dot(path)
+            _from = p.get("from", None)
+            if _from:
+                from_path = to_dot(_from)
+                update["$rename"][from_path] = dot_path
+            else:
+                raise JsonPatch2PyMongoException("Unsupported Operation! can't use move op without from")
+
         elif op == "test":
             pass  # the test op does not change the query
         else:

--- a/src/jsonpatch2pymongo/main.py
+++ b/src/jsonpatch2pymongo/main.py
@@ -76,7 +76,9 @@ def jsonpatch2pymongo(patch_list: list) -> dict:
                 from_path = to_dot(_from)
                 update["$rename"][from_path] = dot_path
             else:
-                raise JsonPatch2PyMongoException("Unsupported Operation! can't use move op without from")
+                raise JsonPatch2PyMongoException(
+                    "Unsupported Operation! can't use move op without from"
+                )
 
         elif op == "test":
             pass  # the test op does not change the query

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -136,10 +136,15 @@ def test_jp2pym_add_treated_as_replace():
 
 
 def test_jp2pym_raise_on_move():
-    patches = [{"op": "move", "path": "/name", "from": "/old_name"}]
+    patches = [{"op": "move", "path": "/name"}]
     with pytest.raises(JsonPatch2PyMongoException):
-        jsonpatch2pymongo(patches)
+        jsonpatch2pymongo(patches)    
 
+
+def test_jp2pym_move():
+    patches = [{"op": "move", "path": "/name", "from": "/old_name"}]
+    expected = {"$rename": {"old_name": "name"}}
+    assert expected == jsonpatch2pymongo(patches)
 
 def test_jp2pym_raise_on_copy():
     patches = [{"op": "copy", "path": "/name", "from": "/old_name"}]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -138,13 +138,14 @@ def test_jp2pym_add_treated_as_replace():
 def test_jp2pym_raise_on_move():
     patches = [{"op": "move", "path": "/name"}]
     with pytest.raises(JsonPatch2PyMongoException):
-        jsonpatch2pymongo(patches)    
+        jsonpatch2pymongo(patches)
 
 
 def test_jp2pym_move():
     patches = [{"op": "move", "path": "/name", "from": "/old_name"}]
     expected = {"$rename": {"old_name": "name"}}
     assert expected == jsonpatch2pymongo(patches)
+
 
 def test_jp2pym_raise_on_copy():
     patches = [{"op": "copy", "path": "/name", "from": "/old_name"}]


### PR DESCRIPTION
To help complete with the implementation of the RFC of jsonpatch, I am submitting a PR for `move` operations. Move operations are equivalent to `$rename` in mongodb.

<img width="1006" alt="Screen Shot 2021-12-12 at 3 33 49 PM" src="https://user-images.githubusercontent.com/52769025/145734142-f9ea536d-eab1-4ac1-926d-ea4fce77caea.png">

Example:
```
from jsonpatch2pymongo import jsonpatch2pymongo
import jsonpatch

obj = { 'a': '1' }
obj2 = { 'b': '1' }
print(jsonpatch2pymongo(jsonpatch.make_patch(obj, obj2)))
# prints {'$rename': {'a': 'b'}}
```
